### PR TITLE
jabadia - phantom layer

### DIFF
--- a/lib/edit/offlineFeaturesManager.js
+++ b/lib/edit/offlineFeaturesManager.js
@@ -139,9 +139,14 @@ define([
 				return this._nextTempId--;
 			};
 
-			layer._phantomLayer = new GraphicsLayer({opacity:0.8});
-			layer._phantomLayer.disableMouseEvents();
-			layer._map.addLayer(layer._phantomLayer);
+			function initPhantomLayer()
+			{
+				layer._phantomLayer = new GraphicsLayer({opacity:0.8});
+				layer._phantomLayer.disableMouseEvents();
+				var index = layer.getMap().graphicsLayerIds.indexOf(layer.id);
+				layer._map.addLayer(layer._phantomLayer,index-1);
+			}
+			initPhantomLayer();
 
 		}, // extend
 
@@ -151,46 +156,42 @@ define([
 		{
 			if( this._phantomSymbols.length == 0)
 			{
+				var color = [0,255,0,255];
+				var width = 4;
+
 				this._phantomSymbols['point'] = [];
 				this._phantomSymbols['point'][editsStore.ADD] = new SimpleMarkerSymbol({
 					"type": "esriSMS", "style": "esriSMSCross",
 					"xoffset": 10, "yoffset": 10,
 					"color": [255,255,255,0], "size": 15,
-					"outline": { "color": [0,255,255,255], "width": 4, "type": "esriSLS", "style": "esriSLSSolid" }
+					"outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
 				});
 				this._phantomSymbols['point'][editsStore.UPDATE] = new SimpleMarkerSymbol({
 					"type": "esriSMS", "style": "esriSMSCircle",
 					"xoffset": 0, "yoffset": 0,
 					"color": [255,255,255,0], "size": 15,
-					"outline": { "color": [0,255,255,255], "width": 4, "type": "esriSLS", "style": "esriSLSSolid" }
+					"outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
 				});
 				this._phantomSymbols['point'][editsStore.DELETE] = new SimpleMarkerSymbol({
 					"type": "esriSMS", "style": "esriSMSX",
 					"xoffset": 0, "yoffset": 0,
 					"color": [255,255,255,0], "size": 15,
-					"outline": { "color": [0,255,255,255], "width": 4, "type": "esriSLS", "style": "esriSLSSolid" }
+					"outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
 				});
 				this._phantomSymbols['multipoint'] = null;
-/*
-			g_test.polygonSymbol = new SimpleFillSymbol({
-				"type": "esriSFS",
-				"style": "esriSFSSolid",
-				"color": [115,76,0,255],
-			    "outline": { "type": "esriSLS", "style": "esriSLSSolid", "color": [110,110,110,255], "width": 1 }
-			});
-*/
+
 				this._phantomSymbols['polyline'] = [];
 				this._phantomSymbols['polyline'][editsStore.ADD] = new SimpleLineSymbol({
 					"type": "esriSLS", "style": "esriSLSSolid", 
-					"color": [0,255,255,255],"width": 4 
+					"color": color,"width": width 
 				});
 				this._phantomSymbols['polyline'][editsStore.UPDATE] = new SimpleLineSymbol({
 					"type": "esriSLS", "style": "esriSLSDash", 
-					"color": [0,255,255,255],"width": 4 
+					"color": color,"width": width 
 				});
 				this._phantomSymbols['polyline'][editsStore.DELETE] = new SimpleLineSymbol({
 					"type": "esriSLS", "style": "esriSLSDot", 
-					"color": [0,255,255,255],"width": 4 
+					"color": color,"width": width 
 				});
 
 				this._phantomSymbols['polygon'] = [];
@@ -198,19 +199,19 @@ define([
 					"type": "esriSFS",
 					"style": "esriSFSSolid",
 					"color": [255,255,255,0],
-				    "outline": { "type": "esriSLS", "style": "esriSLSSolid", "color": [0,255,255,255], "width": 4 }
+				    "outline": { "type": "esriSLS", "style": "esriSLSSolid", "color": color, "width": width }
 				});
 				this._phantomSymbols['polygon'][editsStore.UPDATE] = new SimpleFillSymbol({
 					"type": "esriSFS",
 					"style": "esriSFSSolid",
 					"color": [255,255,255,0],
-				    "outline": { "type": "esriSLS", "style": "esriSLSDash", "color": [0,255,255,255], "width": 4 }
+				    "outline": { "type": "esriSLS", "style": "esriSLSDash", "color": color, "width": width }
 				});
 				this._phantomSymbols['polygon'][editsStore.DELETE] = new SimpleFillSymbol({
 					"type": "esriSFS",
 					"style": "esriSFSSolid",
 					"color": [255,255,255,0],
-				    "outline": { "type": "esriSLS", "style": "esriSLSDot", "color": [0,255,255,255], "width": 4 }
+				    "outline": { "type": "esriSLS", "style": "esriSLSDot", "color": color, "width": width }
 				});
 			}
 


### PR DESCRIPTION
It works.

But it's not entirely satisfactory, the phantom layer receives events and prevent other layers (the real feature layers) to get the mouse events that allow editing.

I haven't been able to make it "event transparent", so the workaround is to put the phantom layer below the real layer. I would like to revisit this if we find a good solution.

Symbology can also be improved.
