### PR TITLE
fixed "gets level estimation" spec. Working again.

### DIFF
--- a/test/spec/offlineTilesEnablerSpec.js
+++ b/test/spec/offlineTilesEnablerSpec.js
@@ -94,18 +94,20 @@ describe("offline enabler library", function()
 	{
 		require(["esri/geometry/Extent"],function(Extent)
 		{			
-			var extent = new Extent({"xmin":-822542.2830377579,"ymin":4580841.761960262,"xmax":94702.05638410954,"ymax":5131188.365613382,"spatialReference":{"wkid":102100}});
-			var tileSize = g_basemapLayer.estimateTileSize();
-			var estimation = g_basemapLayer.getLevelEstimation(extent,10);
-			expect(estimation.tileCount).toEqual(375);
-			expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);
-			var estimation = g_basemapLayer.getLevelEstimation(extent,8);
-			expect(estimation.tileCount).toEqual(28);
-			expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);
-			var estimation = g_basemapLayer.getLevelEstimation(extent,2);
-			expect(estimation.tileCount).toEqual(2);
-			expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);				
-	        done();
+            var extent = new Extent({"xmin":-822542.2830377579,"ymin":4580841.761960262,"xmax":94702.05638410954,"ymax":5131188.365613382,"spatialReference":{"wkid":102100}});
+			g_basemapLayer.estimateTileSize(function(tileSize){
+                var estimation = g_basemapLayer.getLevelEstimation(extent,10,tileSize);
+                expect(estimation.tileCount).toEqual(375);
+                expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);
+
+                var estimation = g_basemapLayer.getLevelEstimation(extent,8,tileSize);
+                expect(estimation.tileCount).toEqual(28);
+                expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);
+                var estimation = g_basemapLayer.getLevelEstimation(extent,2,tileSize);
+                expect(estimation.tileCount).toEqual(2);
+                expect(estimation.sizeBytes).toEqual(estimation.tileCount * tileSize);
+                done();
+            }.bind(this));
 		});
 	});
 


### PR DESCRIPTION
I've looked at this again and can't think of a better way to get a level estimation that provides a comparable level of accuracy.  It's important to note, our previous pattern gave estimates that were off by up to 50% or more MBs.

"If" we could get access to the guts of getTileUrl() then we could actually grab the real image size right from the JS library very early in the life cycle and remove the performance hit we are taking. This is certainly something worth investigating and would provide significantly simpler code.

While I don't like this callback based approach, I'm thinking significantly better accuracy trumps simplicity in this case because storage space is so limited in the browser. This is especially true when running this library on a mobile device and not on a laptop, as well as if indexedDB space is being taken up by other storage needs. 
