### PR TITLE
jabadia - solve compatibility with 3.8

### DIFF
--- a/lib/tiles/offlineTilesEnabler.js
+++ b/lib/tiles/offlineTilesEnabler.js
@@ -66,11 +66,7 @@ define([
                  */
                 layer.getTileUrl = function(level,row,col)
                 {
-                    if(isNaN(level) || isNaN(row) || isNaN(col) )
-                    {
-                        console.log("level,row,col:",level,row,col);
-                        return null;
-                    }
+                    console.assert(!isNaN(level) && !isNaN(row) && !isNaN(col), "bad tile requested");
 
                     console.log("looking for tile",level,row,col);
                     var url = this._getTileUrl(level,row,col);


### PR DESCRIPTION
fixed now
three simple changes, diff seems more complex because of the change in indentation:
- layer.resampling = false
- temp url is now void:/level/row/col, as tiledlayer code seems to split the returned url by '/' to get level row and col values
- NaN hack is left as an assert check. We shouldn't get any NaN values anymore. They were caused by the API trying to split the "void:level-row-col" url that we gave it by '/'. Now we give them something more similiar to what they expect, and everything works.
