### PR TITLE
fixes some breaking changes from last nights PR

### DIFF
--- a/lib/edit/offlineFeaturesManager.js
+++ b/lib/edit/offlineFeaturesManager.js
@@ -86,7 +86,10 @@ define([
                 }
                 else
                 {
-                    return {"attachmentInfos":[]};
+                    //Needs to return a deferred
+                    //TODO we should check if the objectId resides in local database
+                    var deferred = new Deferred();
+                    return deferred;
                 }
             }
 

--- a/lib/resource-proxy/proxy.config
+++ b/lib/resource-proxy/proxy.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ProxyConfig allowedReferers="*"
-             logFile="proxy_log.log"
              mustMatch="true">
     <serverUrls>
         <serverUrl url="http://services.arcgisonline.com"

--- a/lib/resource-proxy/proxy_log.log
+++ b/lib/resource-proxy/proxy_log.log
@@ -1,5 +1,0 @@
-
- 
-02-25-14 01:04:21 | FILES detected
-02-25-14 01:04:22 | Ok to proxy
-02-25-14 01:04:22 | Proxy complete

--- a/test/spec/offlineTilesEnablerSpec.js
+++ b/test/spec/offlineTilesEnablerSpec.js
@@ -159,7 +159,7 @@ describe("offline enabler library", function()
 			
 			g_basemapLayer.goOffline();
 			var offlineUrl = fakeTile.src = g_basemapLayer.getTileUrl(14,6178,8023);
-			expect(offlineUrl).toEqual('void:14-6178-8023');
+			expect(offlineUrl).toEqual('void:/14/6178/8023');
 			done();
 		})
 	});


### PR DESCRIPTION
Fixes unit tests in offlineTileEnabler. New way of handling tiles injects slashes "/"

Removed need for proxy to create/write to a log file. Good catch!

queryAttachmentInfos now returns a deferred.
