### PR TITLE
Fixes issue #155

### DIFF
--- a/lib/tiles/dbStore.js
+++ b/lib/tiles/dbStore.js
@@ -64,7 +64,7 @@ define([],function()
                 };
 
                 var objectStore = transaction.objectStore("tilepath");
-                var request = objectStore.put(urlDataPair);
+                var request = objectStore.add(urlDataPair);
                 request.onsuccess = function(event) {
                     //console.log("item added to db " + event.target.result);
                 };


### PR DESCRIPTION
dbstore.js now correctly throws an error when attempting to store a duplicate entry in Chrome and Firefox.

Tested on Chrome 33.0.1750.152 and Firefox 28. 

NOTE: there is a bug in indexedDBShim on Safari which prevented the shim from correctly reporting duplicates https://github.com/axemclion/IndexedDBShim/issues/118
