### PR TITLE
tile sample usability improvement

### DIFF
--- a/samples/tiles-indexed-db.html
+++ b/samples/tiles-indexed-db.html
@@ -502,9 +502,9 @@ require(
 
 			var totalEstimation = { tileCount:0, sizeBytes:0 }
 
-			domConstruct.empty('tile-count-table-body');
-
-            basemapLayer.estimateTileSize(function(tileSize){
+            basemapLayer.estimateTileSize(function(tileSize)
+            {
+				domConstruct.empty('tile-count-table-body');
 
                 for(var level=minLevel; level<=maxLevel; level++)
                 {


### PR DESCRIPTION
small change that avoids flickering of the level size estimation table when panning around, and also a "repeated table" effect that happend from time to time when panning around heavily
