### PR TITLE
jabadia delete local attachments

### DIFF
--- a/lib/edit/attachmentsStore.js
+++ b/lib/edit/attachmentsStore.js
@@ -179,7 +179,7 @@ define([], function()
                     .delete(attachmentId);
                 request.onsuccess = function(event)
                 {
-                    callback(true);
+                    setTimeout(function(){callback(true);},1);
                 };
                 request.onerror = function(err)
                 {

--- a/lib/edit/offlineFeaturesManager.js
+++ b/lib/edit/offlineFeaturesManager.js
@@ -140,7 +140,7 @@ define([
             1. add a new attachment to an existing feature (DONE)
             2. add a new attachment to a new feature (DONE)
             3. remove an attachment that is already in the server... (NOT YET)
-            4. remove an attachment that is not in the server yet (NOT YET)
+            4. remove an attachment that is not in the server yet (DONE)
             5. update an existing attachment to an existing feature (NOT YET)
             6. update a new attachment (NOT YET)
 
@@ -149,10 +149,10 @@ define([
               an attachment to a feature that is still offline? we need to keep track of objectids so that when
               the feature is sent to the server and receives a final objectid we replace the temporary negative id
               by its final objectid (DONE)
-            - what if the user deletes an offline feature that had offline attachments? we need to discard the attachment  (NOT YET)
+            - what if the user deletes an offline feature that had offline attachments? we need to discard the attachment  (DONE)
 
             pending tasks:
-            - delete attachment (NOT YET)
+            - delete attachment (DONE)
             - send attachments to server when reconnecting (DONE)
             - check for hasAttachments attribute in the FeatureLayer (NOT YET)
             */            
@@ -259,7 +259,6 @@ define([
                     var def = this._deleteAttachments(objectId,attachmentsIds,
                         function()
                         {
-                            self.emit(self.events.ATTACHMENTS_DELETED,arguments);
                             callback && callback.apply(this,arguments);
                         },
                         function(err)
@@ -275,12 +274,33 @@ define([
                     console.log("in order to support attachments you need to call initAttachments() method of offlineFeaturesManager");                        
                 }
 
-                // TODO        
-                console.assert(false, "not implemented");            
-
                 // case 1.- it is a new attachment
-
                 // case 2.- it is an already existing attachment
+                // only case 1 is supported right now
+
+                // asynchronously delete each of the attachments
+                var promises = [];
+                attachmentsIds.forEach(function(attachmentId)
+                {
+                    attachmentId = parseInt(attachmentId,10); // to number
+                    console.assert( attachmentId<0 , "we only support deleting local attachments");
+                    var deferred = new Deferred();
+                    self.attachmentsStore.delete(attachmentId, function(success)
+                    {
+                        var result = { objectId: objectId, attachmentId: attachmentId, success: success };
+                        deferred.resolve(result);
+                    });
+                    promises.push(deferred);
+                }, this);
+
+                // call callback once all deletes have finished
+                var allPromises = all(promises);
+                allPromises.then( function(results)
+                {
+                    callback && callback(results);
+                });
+                
+                return allPromises;
             };
 
             //

--- a/test/spec/offlineAttachmentsSpec.js
+++ b/test/spec/offlineAttachmentsSpec.js
@@ -373,13 +373,70 @@ describe("Attachments", function()
 
 	describe("delete attachments", function()
 	{
-		/*
+		var attachmentId;
+
+		async.it("add attachment", function(done)
+		{
+			expect(g_featureLayers[3].graphics.length).toBe(2);
+			expect(g_offlineFeaturesManager.attachmentsStore).not.toBeUndefined();
+
+			expect(g2_offline.attributes.objectid).toBeLessThan(0);
+
+			g_featureLayers[3].addAttachment( g2_offline.attributes.objectid, g_formNode, 
+				function(result)
+				{
+					attachmentId = result.attachmentId;
+
+					console.log(result);
+					expect(result).not.toBeUndefined();
+					expect(result.attachmentId).toBeLessThan(0);
+					expect(result.objectId).toBe( g2_offline.attributes.objectid );
+					g_offlineFeaturesManager.attachmentsStore.getUsage(function(usage)
+					{
+						expect(usage.attachmentCount).toBe(3);
+						g_offlineFeaturesManager.attachmentsStore.getAttachmentsByFeatureId(g_featureLayers[3].url, g2_offline.attributes.objectid, function(attachments)
+						{
+							expect(attachments.length).toBe(2);
+							done();
+						});
+					});
+				},
+				function(err)
+				{
+					expect(true).toBeFalsy();
+					done();			
+				}
+			);
+		});
+
 		async.it("delete attachment", function(done)
 		{
-			expect(false).toBeTruthy(); // not implemented
-			done();
+			expect(g_featureLayers[3].graphics.length).toBe(2);
+			expect(g_offlineFeaturesManager.attachmentsStore).not.toBeUndefined();
+
+			g_featureLayers[3].deleteAttachments( g2_offline.attributes.objectid, [attachmentId],
+				function(result)
+				{
+					console.log(result);
+					expect(result).not.toBeUndefined();
+
+					g_offlineFeaturesManager.attachmentsStore.getUsage(function(usage)
+					{
+						expect(usage.attachmentCount).toBe(2);
+						g_offlineFeaturesManager.attachmentsStore.getAttachmentsByFeatureId(g_featureLayers[3].url, g2_offline.attributes.objectid, function(attachments)
+						{
+							expect(attachments.length).toBe(1);
+							done();
+						});
+					});
+				},
+				function(err)
+				{
+					expect(true).toBeFalsy();
+					done();			
+				}
+			);
 		});
-		*/
 	});
 
 	describe("go Online and finish all", function()
@@ -388,9 +445,9 @@ describe("Attachments", function()
 		{
 			g_offlineFeaturesManager.attachmentsStore.getAttachmentsByFeatureLayer(g_featureLayers[3].url, function(attachments)
 			{
-				expect(attachments.length).toBe(3);
+				expect(attachments.length).toBe(2);
 				var objectIds = attachments.map(function(a){ return a.objectId; }).sort();
-				expect(objectIds).toEqual([g1_online.attributes.objectid, g2_offline.attributes.objectid, g3_offline.attributes.objectid].sort());
+				expect(objectIds).toEqual([g1_online.attributes.objectid, g2_offline.attributes.objectid].sort());
 				done();
 			});
 		});


### PR DESCRIPTION
things included in this PR:
- handle some corner cases (user deletes an offline feature that has attachments)
- support for deleting attachments (only local attachments)

things not included (yet)
- support for viewing local attachments
- check for hasAttachments attribute to allow/disallow attachment handling
- update README.md
- improve attachments-editor.html to report status of attachments storage
