### PR TITLE
string-indexed phantom symbols

### DIFF
--- a/lib/edit/offlineFeaturesManager.js
+++ b/lib/edit/offlineFeaturesManager.js
@@ -563,55 +563,55 @@ define([
                 var color = [0,255,0,255];
                 var width = 1.5;
 
-                this._phantomSymbols.point = [];
-                this._phantomSymbols.point[editsStore.ADD] = new SimpleMarkerSymbol({
+                this._phantomSymbols['point'] = [];
+                this._phantomSymbols['point'][editsStore.ADD] = new SimpleMarkerSymbol({
                     "type": "esriSMS", "style": "esriSMSCross",
                     "xoffset": 10, "yoffset": 10,
                     "color": [255,255,255,0], "size": 15,
                     "outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
                 });
-                this._phantomSymbols.point[editsStore.UPDATE] = new SimpleMarkerSymbol({
+                this._phantomSymbols['point'][editsStore.UPDATE] = new SimpleMarkerSymbol({
                     "type": "esriSMS", "style": "esriSMSCircle",
                     "xoffset": 0, "yoffset": 0,
                     "color": [255,255,255,0], "size": 15,
                     "outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
                 });
-                this._phantomSymbols.point[editsStore.DELETE] = new SimpleMarkerSymbol({
+                this._phantomSymbols['point'][editsStore.DELETE] = new SimpleMarkerSymbol({
                     "type": "esriSMS", "style": "esriSMSX",
                     "xoffset": 0, "yoffset": 0,
                     "color": [255,255,255,0], "size": 15,
                     "outline": { "color": color, "width": width, "type": "esriSLS", "style": "esriSLSSolid" }
                 });
-                this._phantomSymbols.multipoint = null;
+                this._phantomSymbols['multipoint'] = null;
 
-                this._phantomSymbols.polyline = [];
-                this._phantomSymbols.polyline[editsStore.ADD] = new SimpleLineSymbol({
+                this._phantomSymbols['polyline'] = [];
+                this._phantomSymbols['polyline'][editsStore.ADD] = new SimpleLineSymbol({
                     "type": "esriSLS", "style": "esriSLSSolid",
                     "color": color,"width": width
                 });
-                this._phantomSymbols.polyline[editsStore.UPDATE] = new SimpleLineSymbol({
+                this._phantomSymbols['polyline'][editsStore.UPDATE] = new SimpleLineSymbol({
                     "type": "esriSLS", "style": "esriSLSSolid", 
                     "color": color,"width": width
                 });
-                this._phantomSymbols.polyline[editsStore.DELETE] = new SimpleLineSymbol({
+                this._phantomSymbols['polyline'][editsStore.DELETE] = new SimpleLineSymbol({
                     "type": "esriSLS", "style": "esriSLSSolid", 
                     "color": color,"width": width
                 });
 
-                this._phantomSymbols.polygon = [];
-                this._phantomSymbols.polygon[editsStore.ADD] = new SimpleFillSymbol({
+                this._phantomSymbols['polygon'] = [];
+                this._phantomSymbols['polygon'][editsStore.ADD] = new SimpleFillSymbol({
                     "type": "esriSFS",
                     "style": "esriSFSSolid",
                     "color": [255,255,255,0],
                     "outline": { "type": "esriSLS", "style": "esriSLSSolid", "color": color, "width": width }
                 });
-                this._phantomSymbols.polygon[editsStore.UPDATE] = new SimpleFillSymbol({
+                this._phantomSymbols['polygon'][editsStore.UPDATE] = new SimpleFillSymbol({
                     "type": "esriSFS",
                     "style": "esriSFSSolid",
                     "color": [255,255,255,0],
                     "outline": { "type": "esriSLS", "style": "esriSLSDash", "color": color, "width": width }
                 });
-                this._phantomSymbols.polygon[editsStore.DELETE] = new SimpleFillSymbol({
+                this._phantomSymbols['polygon'][editsStore.DELETE] = new SimpleFillSymbol({
                     "type": "esriSFS",
                     "style": "esriSFSSolid",
                     "color": [255,255,255,0],


### PR DESCRIPTION
No matter what jshint says, these are not really properties, but string-indexed elements. We access them later with a string index that comes in the geometry.type property. I believe the code is clearer this way.
