### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/lib/tiles/README.md
+++ b/lib/tiles/README.md
@@ -1,4 +1,4 @@
-##FileSaver.js
+## FileSaver.js
 ==============
 
 The awesome FileSaver.js library by Eli Grey is licensed under the MIT/X11 license.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
